### PR TITLE
fixup make run-on-kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ endif
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
-CONTAINER_TOOL ?= docker
+CONTAINER_TOOL_PATH := $(shell which docker 2>/dev/null || which podman)
+CONTAINER_TOOL ?= $(shell basename ${CONTAINER_TOOL_PATH})
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -298,7 +299,7 @@ undeploy-on-kind: ## Undeploy operator and agent from the Kind GPU cluster.
 	@echo "Undeployment from Kind GPU cluster $(KIND_CLUSTER_NAME) completed."
 
 .PHONY: run-on-kind
-run-on-kind: setup-kind kind-load-images deploy-on-kind ## Setup Kind cluster, load images, and deploy
+run-on-kind: destroy-kind setup-kind kind-load-images deploy-on-kind ## Setup Kind cluster, load images, and deploy
 	@echo "Cluster created, images loaded, and agent deployed on Kind GPU cluster."
 
 ##@ Dependencies
@@ -383,7 +384,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Containerfile -t $(BUNDLE_IMG) .
+	$(CONTAINER_TOOL) build -f bundle.Containerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.


### PR DESCRIPTION
`make run-on-kind` was failing on the `kind-load-images` step because it couldn't find the cluster. The create and delete steps use the KIND_GPU_SIM_SCRIPT script defined in the kind-gpu-sim repo, where-as load was calling kind directly, The script sets DOCKER_HOST and KIND_EXPERIMENTAL_PROVIDER to allow podman to be used with kind. If these variables are set in the local shell, everything works as expected. But to make it easier on the user, the KIND_GPU_SIM_SCRIPT script was extended to also support the load command.

If the user wants to access the cluster via kind (i.e. `kind get clusters` or `kind get nodes`), DOCKER_HOST and KIND_EXPERIMENTAL_PROVIDER still must be set in the local shell.

There was also a bug in the where the KIND_GPU_SIM_SCRIPT script was being called. The script is expecting to be called like `./kind-gpu-sim.sh delete --cluster-name=$(KIND_CLUSTER_NAME)`, but was being called without the `=`, `./kind-gpu-sim.sh delete --cluster-name $(KIND_CLUSTER_NAME)`. The script was just using default values instead of taking input from the Makefile.

`make docker-build` was outputting the following WARNING, so I don't think it was ever generating a usable image.

```
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
```

Added `--load` to the docker build commands.