### PR TITLE
docs: add gRPC details to design doc

### DIFF
--- a/docs/design/architechture.md
+++ b/docs/design/architechture.md
@@ -22,18 +22,24 @@ optimization and security.
 The TKM Operator focuses on:
 
 - Validating Triton kernel cache image signatures.
+- Aggregating node-level status of each kernel cache.
 - Supporting both cluster and namespace-scoped CRDs to improve security and
   flexibility
 
 The TKM Agent focuses on:
 
 - Detecting GPU hardware and driver versions on each node.
-- Validating cache compatibility against the node's hardware.
+- Validating cache compatibility against the node's hardware (per GPU).
 - Reporting status to the control plane via node-specific CRs.
+- Tracking the status of all kernel caches for all GPUs on the node (via TCM).
+- Communicates with the CSI plugin via GRPC.
 
 The CSI Plugin focuses on:
 
 - Facilitating seamless cache extraction and mounting via a CSI plugin
+- Validating cache compatibility by consulting the TKM Agent via gRPC before
+  extraction.
+- Does not directly access the Kubernetes API.
 
 This clear separation of concerns ensures that the CSI plugin does not perform
 image validation, while the operator remains focused on image inspection and
@@ -43,6 +49,7 @@ verification.
 
 - Decouple kernel image validation from mounting
 - Integrate with TCV for cache image inspection and validation
+- Provide efficient per-GPU kernel compatibility tracking.
 - Provide both cluster and namespace-scoped CRDs
 - Maintain the controller as a long-running daemon for consistent state
   management and responsiveness
@@ -52,51 +59,53 @@ verification.
 ### Components
 
 ```bash
-                 ┌───────────────────────────────────────┐
-                 │ Control Plane                         │
-                 │                                       │
-                 │ ┌───────────────────────────────────┐ │
-                 │ │ TritonKernelCache (CR)            │ │
-                 │ │ - ociImage                        │ │
-                 │ │ - Load Status Summary             │ │
-                 │ └─────────────────┬─────────────────┘ │
-                 │                   │                   │
-                 │                   ▼                   │
-                 │ ┌───────────────────────────────────┐ │
-                 │ │ Operator/controller (Deployment)  │ │
-                 │ │ - Runs on control plane           │ │
-                 │ │ - Registers CSI Driver            │ │
-                 │ │ - Launches TKM Agent              │ │
-                 │ │ - Tracks overall status across    │ │
-                 │ │   all nodes in TritonKernelCache  │ │
-                 │ └─────────────────┬─────────────────┘ │
-                 │                   │                   │
-                 └───────────────────┼───────────────────┘
+                 ┌─────────────────────────────────────────────────┐
+                 │ Control Plane                                   │
+                 │                                                 │
+                 │ ┌───────────────────────────────────┐           │
+                 │ │ TritonKernelCache (CR)            │           │
+                 │ │ - ociImage                        │           │
+                 │ │ - Load Status Summary             │           │
+                 │ └─────────────────┬─────────────────┘           │
+                 │                   │                             │
+                 │                   ▼                             │
+                 │ ┌─────────────────────────────────────────────┐ │
+                 │ │ Operator/controller (Deployment)            │ │
+                 │ │ - Runs on control plane                     │ │
+                 │ │ - Registers CSI Driver                      │ │
+                 │ │ - Launches TKM Agent                        │ │
+                 │ │ - Tracks overall status across              │ │
+                 │ │   all nodes in TritonKernelCacheNodeStatus  │ │
+                 │ └─────────────────┬───────────────────────────┘ │
+                 │                   │                             │
+                 └───────────────────┼─────────────────────────────┘
                                      │
                  ┌───────────────────┴───────────────────┐
                  │ Worker Node                           │
                  │                                       │
                  │ ┌───────────────────────────────────┐ │
                  │ │ TritonKernelCacheNodeStatus (CR)  │ │
-                 │ │ - GPU Info                        │ │
-                 │ │ - Node Load Status                │ │
+                 │ │ - GPU Info (per-GPU)              │ │
+                 │ │ - Node Load Status (per-GPU)      │ │
                  │ └─────────────────┬─────────────────┘ │
                  │                   │                   │
                  │                   ▼                   │
                  │ ┌───────────────────────────────────┐ │
                  │ │ TKM Agent (DaemonSet)             │ │
-                 │ │ - Detects GPU Info                │ │
+                 │ │ - Detects GPUs and drivers        │ │
                  │ │ - Validate Image Signature        │ │
                  │ │ - Validates cache compatibility   │ │
                  │ │ - Create/Update node-specific CR  │ │
+                 │ │ - Serves gRPC to CSI plugin       │ │
                  │ └─────────────────┬─────────────────┘ │
                  │                   │                   │
                  │                   ▼                   │
                  │ ┌───────────────────────────────────┐ │
                  │ │ CSI Driver (DaemonSet)            │ │
                  │ │ - Watches pod volumes             │ │
+                 │ │ - Requests gRPC validation        │ │
                  │ │ - Loads kernel cache into volume  │ │
-                 │ │   if "Ready"                      │ │
+                 │ │   if approved by Agent            │ │
                  │ └───────────────────────────────────┘ │
                  └───────────────────────────────────────┘
 ```
@@ -122,28 +131,25 @@ verification.
 
 TKM will support the following CRDs:
 
-- **TritonKernelCache CRD:** Represents the desired state of a kernel cache.
-  Through this CRD, the user can specify the OCI Image, which is the container
-  image containing the kernel binary.
-  This is a namespace scoped CRD.
+- **TritonKernelCache CRD (namespaced):**
+  Declares that workloads in a specific namespace intend to use a Triton GPU
+  kernel resource defined by an OCI image. This is a lightweight reference to
+  a kernel cache image — the actual validation, extraction, and usage tracking
+  are handled by the TKM Agent and CSI driver. This CRD supports multi-tenancy
+  by scoping kernel cache declarations to specific namespaces.
 
   > *[OI] Possible Naming Options (prefer a shorter name):
   > TritonKernelCache/TKMCache/TKMImage/TKMCacheImage/TKMKernelImage*
-- **TritonKernelCacheCluster CRD:** Represents the desired state of a kernel
-  cache.
-  Same as TritonKernelCache CRD, but a cluster scoped CRD.
-- **TritonKernelCacheNodeStatus CRD:** Represents the actual state of a kernel
-  cache for a given Kubernetes Node.
-  The user does not create or modify this object, but is used by TKM to reflect
-  the status a kernel cache for a given Kubernetes Node.
-  One instance of this CRD is created for each node for each `TritonKernelCache`
-  instance.
-  This is a namespace scoped CRD.
-- **TritonKernelCacheNodeStatusCluster CRD:** Represents the actual state of a
-  kernel.
-  Same as TritonKernelCacheNodeStatus CRD, but a cluster scoped CRD.
-  One instance of this CRD is created for each node for each
-  `TritonKernelCacheCluster` instance.
+- **TritonKernelCacheCluster CRD:**
+  Same as TritonKernelCache, but used when the kernel resource is intended for
+  workloads across the entire cluster. Suitable for shared or system-wide kernel
+  caches.
+- **TritonKernelCacheNodeStatus CRD (namespaced):**
+  A TritonKernelCacheNodeStatus resource is created by the Agent to reflect
+  compatibility and readiness of kernel caches for each GPU on the node.
+- **TritonKernelCacheNodeStatusCluster CRD:**
+  Same as TritonKernelCacheNodeStatus, but used when the corresponding kernel
+  cache is defined using a TritonKernelCacheCluster resource
 
 To increase security, the TKM Operator supports a namespace-scoped
 version of the TritonKernelCache CRD.
@@ -162,15 +168,33 @@ Advantages:
 
 > *[OI] Does Namespace Scoped CRD make sense? We cannot isolate the actual
 > GPU to a namespace.*
+> The namespaced CRDs act as a declaration of dependency: This pod needs
+> access to a kernel cache that is compatible with the GPU it will be scheduled on.
+> So Namespaced CRDs ensure that a pod can only request a kernel declared in its own
+> namespace.
 
 #### TritonKernelCache and TritonKernelCacheCluster CRD
 
-The TritonKernelCache and TritonKernelCacheCluster CRDs allow the user
-to specify details about the OCI Image that contains the Triton kernel.
-The data provided allows the image to be downloaded and the Triton kernel
-extracted from the image.
+The TritonKernelCache and TritonKernelCacheCluster CRDs serve as declarations
+of interest in a specific Triton GPU kernel cache, represented by an OCI image.
+These resources inform the TKM system that workloads in the cluster may require
+access to the specified kernel cache.
+
+Users provide the cacheImage field, which points to a valid OCI image containing
+the precompiled Triton kernels. This image is pulled and validated by the TKM
+Agent as needed. The actual management of image signatures, pull secrets, and
+validation policies is handled globally via TKM configuration (e.g., ConfigMap),
+not per resource.
+
+Once specified, the image is internally resolved to its digest (e.g., sha256:...).
+This digest acts as the authoritative identifier throughout the system for validation,
+compatibility checks, cache extraction, and mounting.
+
+GPU compatibility is assessed dynamically by the TKM Agent on a per-node, per-GPU basis.
+The CRD itself does not include any GPU-specific configuration.
 
 > *[OI] Are there any GPU Type specific fields?*
+> I don't think so - as these are in teh image iteself?
 
 Example of TritonKernelCache CRD:
 
@@ -181,62 +205,171 @@ metadata:
   name: kernel-y
   namespace: ml-apps
 spec:
-  ociImage:
-    pullPolicy: IfNotPresent
-    image: quay.io/example/kernel-y:latest
-    pullSecret:
-  validateSignature: false
+  cacheImage: quay.io/example/kernel-y:latest
 status:
   conditions:
-  - lastTransitionTime: "2025-05-08T21:06:07Z"
-    message: 'TritonKernelCache Reconciliation failed on the following TritonKernelCacheNodeStatus
-      objects: [kernel-y-node1]'
-    reason: Error
-    status: "True"
-    type: Error
+    - lastTransitionTime: "2025-05-08T21:06:07Z"
+      message: 'TritonKernelCache reconciliation failed on the following nodes: [node1]'
+      reason: Error
+      status: "True"
+      type: Error
 ```
-
-> *[OI] I don't think we need `validateSignature` here? We will want
-> a TKM configuration option to allow unsigned images and to disable
-> COSign. bpfman had a ConfigMap which contained a configuration file.*
 
 #### TritonKernelCacheNodeStatus and TritonKernelCacheNodeStatusCluster CRD
 
 TritonKernelCacheNodeStatus and TritonKernelCacheNodeStatusCluster CRD instances
 are created by the TKM Agent, not the user.
-There is an instance for each Kubernetes Node for each TritonKernelCache or
-TritonKernelCacheCluster instance.
-The purpose is to provide the status of a given Triton kernel for each node
-as well detected GPU info from the node.
+Each node will have one such CR to represent its status, and it will contain
+information for all kernel caches relevant to that node, organized per GPU.
 
-Summary of data reflected in CRD:
+If the corresponding TritonKernelCache is namespace-scoped, the NodeStatus CR
+should live in the same namespace.If the corresponding TritonKernelCache is c
+luster-scoped, a cluster-scoped NodeStatus CR (TritonKernelCacheNodeStatusCluster)
+will be used instead.
 
-- **nodeName:** The name of the node.
-- **kernelCacheRef:** Reference to the Triton kernel cache.
-- **gpuType:** The type of GPU present.
-- **driverVersion:** Version of the GPU driver.
+While nodes themselves are not namespaced, the namespace of the NodeStatus CR
+follows the scope of the kernel cache resource it reports on. This allows the
+operator to correctly associate status objects with their source cache definitions.
+
+This structure enables more efficient status tracking in environments with
+heterogeneous GPU configurations and supports CSI plugin queries via the TKM Agent.
+
+Summary of data reflected in the CRD:
+
+- **nodeName**: The name of the Kubernetes node.
+- **gpus**: List of physical GPUs on the node with:
+  - **id**: GPU index (e.g., 0–7).
+  - **gpuType**: (e.g., nvidia-a100).
+  - **driverVersion**: The GPU driver version.
+- **caches**: Map of kernel cache identifiers to:
+  - **compatibleGPUs**: List of GPU groups that support the cache.
+  - **incompatibleGPUs**: List of GPU groups that do not support the cache, with reason/message.
+- **lastUpdated**: Timestamp of the last compatibility update.
+
+
+This consolidated per-node, per-GPU view supports scalable monitoring and allows the CSI
+driver to consult the Agent instead of accessing the Kubernetes API directly.
 
 > *[OI] Do need or can we have a used by?*
 
 Example of TritonKernelCacheNodeStatus CRD:
 
 ```yaml
-apiVersion: tkm.io/v1alpha1
-kind: TritonKernelCacheNodeStatus
-metadata:
-  name: kernel-x-node1
-  namespace: ml-apps
 status:
-  conditions:
-    - type: Ready
-      status: "True"
-    - type: Compatible
-      status: "True"
-  driverVersion: 470.57.02
-  kernelCacheRef: kernel-x
-  gpuType: nvidia
-  nodeName: node1
+  gpus:
+    - id: 0
+      gpuType: nvidia-a100
+      driverVersion: 535.43.02
+    - id: 1
+      gpuType: nvidia-a100
+      driverVersion: 535.43.02
+    - id: 2
+      gpuType: nvidia-h100
+      driverVersion: 550.00.01
+    - id: 3
+      gpuType: nvidia-v100
+      driverVersion: 470.57.02
+
+  caches:
+    kernel-x:
+      compatibleGPUs:
+        - ids: [0, 1]
+          gpuType: nvidia-a100
+          driverVersion: 535.43.02
+      incompatibleGPUs:
+        - ids: [3]
+          gpuType: nvidia-v100
+          driverVersion: 470.57.02
+          reason: "Missing SM 7.0"
+          message: "Kernel built only for Ampere+"
+      lastUpdated: "2025-06-03T14:00:00Z"
 ```
+
+#### CSI Cache Extraction and Mounting Behavior
+
+The CSI plugin, after validating kernel cache readiness via the Agent
+(see next section), extracts the kernel cache to a structured directory
+on the node's filesystem. The proposed directory layout is:
+
+```console
+/var/run/tkm/caches/<namespace>/<pod-name>/<cache-id>/
+```
+
+Where <cache-id> is derived from the image digest internally resolved from the
+OCI image provided in the pod spec (e.g., `sha256:abc123`) as resolved from
+the OCI image.
+
+This structure ensures:
+
+-  Isolation across namespaces and pods
+-  Simplified monitoring via Triton Cache Manager (TCM)
+-  Easier cache cleanup and usage tracking by the Agent
+
+By default, the CSI driver mounts this cache directory as read-only into the
+requesting pod to maintain kernel integrity and enable safe sharing between pods.
+
+Applications requiring write access must opt-in by explicitly setting the `readOnly:`
+`false` flag in the volumeAttributes section of the pod spec. The CSI driver receives
+the OCI image reference (e.g., `quay.io/example/kernel-x:latest`) in the pod spec, and
+internally resolves it to the digest to identify and validate the correct cache. The
+digest is not exposed in the pod spec to keep the user interface clean and intuitive.
+
+Additionally, the TKM Agent internally tracks which pods are actively using each kernel
+cache. This internal usage map supports future cleanup, accurate monitoring, and TCM
+integration without exposing this detail in the Kubernetes CRDs.
+
+Example Pod Spec with Writable Cache Mount
+
+##### Example Pod Spec with Writable Cache Mount
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example-pod
+  namespace: ml-apps
+spec:
+  containers:
+    - name: app-container
+      image: example/image:latest
+      volumeMounts:
+        - mountPath: /models/cache
+          name: kernel-cache
+  volumes:
+    - name: kernel-cache
+      csi:
+        driver: csi.tkm.io
+        volumeAttributes:
+          cacheImage: quay.io/example/kernel-x:latest
+          readOnly: "false"
+```
+
+#### gRPC Communication Between CSI Driver and TKM Agent
+
+The CSI driver communicates with the TKM Agent using a local gRPC interface.
+This interaction is central to validating and tracking kernel cache usage
+for pods, and effectively plugs the Agent into the pod lifecycle.
+
+CSI Lifecycle Hooks via gRPC
+
+Mount Request: When the CSI driver mounts a volume for a pod, it makes a
+gRPC call to the TKM Agent to validate the requested kernel cache
+(by resolved digest) for the node and GPU configuration. If the Agent
+confirms the cache is Ready and Compatible, the CSI proceeds with extraction
+and mounting.
+
+Unmount Request: Upon pod deletion or volume unmount, the CSI driver notifies
+the Agent, allowing it to update internal reference counts or perform cleanup
+operations.
+
+This bidirectional communication ensures the TKM Agent maintains an accurate,
+real-time view of which pods are actively using which kernel caches. It also
+opens the door to richer cache lifecycle tracking, future eviction logic,
+and better observability — all without the CSI needing to access Kubernetes
+APIs.
+
+This mechanism effectively ties the TKM Agent into pod scheduling and runtime
+behavior, via its tight integration with CSI.
 
 ##### Pros and Cons of Using a NodeStatus CRD
 


### PR DESCRIPTION
- Align per-node status CRs with MCO-style patterns
- Introduce status summary aggregation into TKMCache CRs
- Rename and simplify node-scoped CRD naming conventions
- Standardise failure reason reporting across CRs using grouped failure types